### PR TITLE
1.x

### DIFF
--- a/FedoraApi.php
+++ b/FedoraApi.php
@@ -793,6 +793,7 @@ class FedoraApiM {
    *       [dsLocationType] => INTERNAL_ID
    *       [dsChecksumType] => DISABLED
    *       [dsChecksum] => none
+   *       [dsChecksumValid] => true
    *   )
    *   @endcode
    *
@@ -1287,6 +1288,56 @@ class FedoraApiM {
     $response = $this->connection->deleteRequest($request);
     $response = $this->serializer->purgeObject($response);
     return $response;
+  }
+
+  /**
+   * Validate an object.
+   *
+   * @param string $pid
+   *    Persistent identifier of the digital object.
+   * @param array $as_of_date_time
+   *   (optional) Indicates that the result should be relative to the
+   *     digital object as it existed at the given date and time. Defaults to
+   *     the most recent version.
+   *
+   * @throws RepositoryException
+   *
+   * @return array
+   *   An array containing the validation results.
+   *   @code
+   *   Array
+   *   (
+   *       [valid] => false
+   *       [contentModels] => Array
+   *           (
+   *               [0] => "info:fedora/fedora-system:FedoraObject-3.0"
+   *           )
+   *       [problems] => Array
+   *           (
+   *               [0] => "Problem description"
+   *           )
+   *       [datastreamProblems] => Array
+   *           (
+   *               [dsid] => Array
+   *               (
+   *                   [0] => "Problem description"
+   *               )
+   *           )
+   *   )
+   *   @endcode
+   */
+  public function validate($pid, $as_of_date_time=NULL){
+    $pid = urlencode($pid);
+
+    $request = "/objects/{$pid}/validate";
+    $seperator = '?';
+
+    $this->connection->addParam($request, $seperator, 'asOfDateTime', $as_of_date_time);
+
+    $response = $this->connection->getRequest($request);
+    $response = $this->serializer->validate($response);
+    return $response;
+
   }
 
   public function upload($file) {

--- a/FedoraApiSerializer.php
+++ b/FedoraApiSerializer.php
@@ -391,6 +391,16 @@ class FedoraApiSerializer {
     return $request['content'];
   }
 
+  /**
+   * Serializes the data returned in FedoraApiM::validate()
+   */
+  public function validate($request){
+    $result = $this->loadSimpleXml($request['content']);
+    $doc = $this->flattenDocument($result);
+    $doc['valid'] = (string) $result['valid'] == "true" ? TRUE : FALSE;
+    return $doc;
+  }
+
   public function upload($request) {
     return $request['content'];
   }

--- a/FedoraApiSerializer.php
+++ b/FedoraApiSerializer.php
@@ -229,7 +229,6 @@ class FedoraApiSerializer {
    * Serializes the data returned in FedoraApiA::listMethods()
    */
   public function listMethods($request) {
-    print_r($request['content']);
     $result = array();
     $object_methods = $this->loadSimpleXml($request['content']);
     // We can't use flattenDocument here because of the atrtibutes.

--- a/FedoraRelationships.php
+++ b/FedoraRelationships.php
@@ -114,6 +114,7 @@ class FedoraRelationships {
    */
   protected function updateDatastream($document) {
       $document->formatOutput = TRUE;
+      $this->datastream->refresh();
       $this->datastream->content = $document->saveXml();
   }
 

--- a/FedoraRelationships.php
+++ b/FedoraRelationships.php
@@ -368,6 +368,8 @@ class FedoraRelsExt extends FedoraRelationships {
       else {
         $ds = $this->object->constructDatastream('RELS-EXT', 'X');
         $ds->label = 'Fedora Object to Object Relationship Metadata.';
+        $ds->format = 'info:fedora/fedora-system:FedoraRELSExt-1.0';
+        $ds->mimetype = 'application/rdf+xml';
         $this->new = TRUE;
       }
 
@@ -507,6 +509,8 @@ class FedoraRelsInt extends FedoraRelationships {
       else {
         $ds = $this->aboutDs->parent->constructDatastream('RELS-INT', 'X');
         $ds->label = 'Fedora Relationship Metadata.';
+        $ds->format = 'info:fedora/fedora-system:FedoraRELSInt-1.0';
+        $ds->mimetype = 'application/rdf+xml';
         $this->new = TRUE;
       }
       $this->datastream = $ds;

--- a/Object.php
+++ b/Object.php
@@ -476,7 +476,8 @@ class FedoraObject extends AbstractFedoraObject {
       $datastreams = $this->repository->api->a->listDatastreams($this->id);
       $this->datastreams = array();
       foreach ($datastreams as $key => $value) {
-        $this->datastreams[$key] = new FedoraDatastream($key, $this, $this->repository);
+          $this->datastreams[$key] = new FedoraDatastream($key, $this, $this->repository, 
+              array("dsLabel" => $value['label'], "dsMIME" => $value['mimetype']));
       }
     }
   }


### PR DESCRIPTION
Three changes: 
- Added a validate() function to FedoraApi and FedoraApiSerializer, which provides access to Fedora's API-M validate() function
- When RELS-EXT and RELS-INT datastreams are created, they should be populated with a MimeType of application/rdf+xml and a proper formatURI
- When a FedoraDatastream object is initialized, without the optional fourth param ($datastream_info), then the object will fetch these values from Fedora using the getDatastream() method. This method, however, is part of API-M, and so it may not be accessible by the user in question, who may only need access to the Datastream::content, Datastream::mimetype, and Datastream::label values. By passing in those values -- retrieved from listDatastreams(), API-M access is completely avoided.
