### PR TITLE
Added log messages for object and datastream ingest

### DIFF
--- a/FedoraApi.php
+++ b/FedoraApi.php
@@ -632,6 +632,7 @@ class FedoraApiM {
    *       [dsLocationType] => INTERNAL_ID
    *       [dsChecksumType] => DISABLED
    *       [dsChecksum] => none
+   *       [dsLogMessage] =>
    *   )
    *   @endcode
    *

--- a/Repository.php
+++ b/Repository.php
@@ -184,7 +184,7 @@ class FedoraRepository extends AbstractRepository {
 
     $dom = new FoxmlDocument($object);
     $xml = $dom->saveXml();
-    $id = $this->api->m->ingest(array('string' => $xml));
+    $id = $this->api->m->ingest(array('string' => $xml, 'logMessage' => $object->logMessage));
     $object = new FedoraObject($id, $this);
     $this->cache->set($id, $object);
     return $object;


### PR DESCRIPTION
I've added Fedora log messages for ingesting new objects and new datastreams. I've used the same pattern with the magic properties so everything should work in the same way. 
