### PR TITLE
Match case when calling a function

### DIFF
--- a/FedoraRelationships.php
+++ b/FedoraRelationships.php
@@ -500,7 +500,7 @@ class FedoraRelsExt extends FedoraRelationships {
    */
   public function get($predicate_uri = NULL, $predicate = NULL, $object = NULL, $literal = FALSE) {
     $this->initializeDatastream();
-    return parent::internalget($this->object->id, $predicate_uri, $predicate, $object, $literal);
+    return parent::internalGet($this->object->id, $predicate_uri, $predicate, $object, $literal);
   }
 
   public function changeObjectID($id) {


### PR DESCRIPTION
PHP functions are case-insensitive, but it is still good form to act as though function names _were_ case sensitive.
