### PR TITLE
add option to use resource index to retrieve object properties

### DIFF
--- a/Repository.php
+++ b/Repository.php
@@ -110,6 +110,12 @@ class FedoraRepository extends AbstractRepository {
 
   public $api;
 
+  /**
+   * Object relations can be retrieved directly from the RELS-* datastreams
+   * (the default) or by using the resource index.
+   */
+  public $useResourceIndex = FALSE;
+
   protected $queryClass = 'RepositoryQuery';
   protected $newObjectClass = 'NewFedoraObject';
   protected $objectClass = 'FedoraObject';


### PR DESCRIPTION
This adds a configurable property to the FedoraRepository class, indicating whether to use the resource index to retrieve certain object properties such as models and parents instead of using RELS-EXT.
