### PR TITLE
PHP 5.4+ issue

### DIFF
--- a/FedoraApiSerializer.php
+++ b/FedoraApiSerializer.php
@@ -107,7 +107,7 @@ class FedoraApiSerializer {
    *   An array representation of the XML.
    */
   protected function flattenDocument($xml, $make_array = array()) {
-    if (!$xml) {
+    if (!is_object($xml)) {
       return '';
     }
 


### PR DESCRIPTION
SimpleXML objects seem to be handled differently in 5.4+
Could also check type... should be SimpleXMLElement?
