### PR TITLE
Added a method to access a user's fedora attributes

### DIFF
--- a/FedoraApi.php
+++ b/FedoraApi.php
@@ -139,6 +139,36 @@ class FedoraApiA {
     return $response;
   }
 
+  /*
+   * Authenticate and provide basic information about user attributes
+   *
+   * @return array()
+   *    Returns an array containing user attributes (i.e. fedoraRole).
+   *    @code
+   *    Array
+   *    (
+   *        [fedoraRole] => Array
+   *            (
+   *                [0] => authenticated user
+   *            )
+   *        [role] => Array
+   *            (
+   *                [0] => authenticated user
+   *            )
+   *    )
+   *    @endcode
+   */
+  public function userAttributes() {
+    $request = "/user";
+    $separator = '?';
+
+    $this->connection->addParam($request, $separator, 'xml', 'true');
+
+    $response = $this->connection->getRequest($request);
+    $response = $this->serializer->userAttributes($response);
+    return $response;
+  }
+
   /**
    * Query fedora to return a list of objects.
    *

--- a/FedoraApi.php
+++ b/FedoraApi.php
@@ -140,7 +140,10 @@ class FedoraApiA {
   }
 
   /*
-   * Authenticate and provide basic information about user attributes
+   * Authenticate and provide basic information about a user's
+   * fedora attributes. Please note that calling this method
+   * with an unauthenticated (i.e. anonymous) user will throw
+   * an 'HttpConnectionException' with the message 'Unauthorized'. 
    *
    * @return array()
    *    Returns an array containing user attributes (i.e. fedoraRole).

--- a/FedoraApiSerializer.php
+++ b/FedoraApiSerializer.php
@@ -154,6 +154,22 @@ class FedoraApiSerializer {
   }
 
   /**
+   * Serializes the data returned in FedoraApiA::userAttributes()
+   */
+  public function userAttributes($request) {
+      $user_attributes = $this->loadSimpleXml($request['content']);
+      $data = Array();
+      foreach($user_attributes->attribute as $attribute){
+          $values = Array();
+          foreach($attribute->value as $value){
+              array_push($values, (string)$value);
+          }
+          $data[(string)$attribute['name']] = $values;
+      }
+      return $data;
+  }
+
+  /**
    * Serializes the data returned in FedoraApiA::findObjects()
    */
   public function findObjects($request) {

--- a/tests/FedoraApiTest.php
+++ b/tests/FedoraApiTest.php
@@ -38,6 +38,12 @@ class FedoraApiIngestTest extends PHPUnit_Framework_TestCase {
     }
   }
 
+  public function testUserAttributes() {
+      $attributes = $this->apia->userAttributes();
+      $this->assertArrayHasKey('role', $attributes);
+      $this->assertArrayHasKey('fedoraRole', $attributes);
+  }
+
   public function testDescribeRepository() {
     $describe = $this->apia->describeRepository();
     $this->assertArrayHasKey('repositoryName', $describe);


### PR DESCRIPTION
This method accesses Fedora's userServlet (http://localhost/fedora/user), returning an array of the user values such as their 'role' or 'fedoraRole'.
