### PR TITLE
Facilitate datastream copying.

### DIFF
--- a/Datastream.php
+++ b/Datastream.php
@@ -1788,7 +1788,8 @@ class CopyOnWriteFedoraDatastream extends AbstractFedoraDatastream {
     $this->wrapped_datastream->logMessage = 'Datastream contents copied on write.';
 
     //XXX: This will break if the Fedora object will actually purge the object
-    //  on an "unset"...
+    //  on an "unset"...  Shouldn't happen, as we require $parent to be a
+    //  NewFedoraObject, which just unsets it.
     unset($this->parent[$this->wrapped_datastream->id]);
 
     $this->parent->ingestDatastream($this->wrapped_datastream);

--- a/Datastream.php
+++ b/Datastream.php
@@ -1732,3 +1732,145 @@ class FedoraDatastream extends AbstractExistingFedoraDatastream implements Count
     return $this->getDatastreamContent(NULL, $file);
   }
 }
+
+/**
+ * Wraps a FedoraDatastream; creates a NewFedoraDatastream when mutated.
+ *
+ * Will only maintain the latest version of the given datastream.
+ * XXX: May break if any wrapped objects override the MagicPropery methods.
+ */
+class CopyOnWriteFedoraDatastream extends AbstractFedoraDatastream {
+  /**
+   * @var NewFedoraDatastream|FedoraDatastream
+   *   The COW datastream itself.
+   */
+  protected $wrapped_datastream;
+
+  /**
+   * Constructor; call inherited, and store the wrapped datastream.
+   *
+   * @param NewFedoraObject $parent
+   *   
+   */
+  public function __construct(NewFedoraObject $parent, $wrapped_datastream) {
+    parent::__construct($wrapped_datastream->id, $parent, $parent->repository);
+    $this->wrapped_datastream = $wrapped_datastream;
+  }
+
+  protected function createNewDatastreamCopy() {
+    $old_datastream = $this->wrapped_datastream;
+
+    $this->wrapped_datastream = $this->parent->constructDatastream($old_datastream->id, $old_datastream->controlGroup);
+
+    // Copying the datastream particulars...
+    $properties = array('checksumType', 'checksum', 'format', 'mimetype', 'versionable', 'label', 'state');
+    if (in_array($old_datastream->controlGroup, array('R', 'E'))) {
+      $properties[] = 'url';
+    }
+    else {
+      // Get the content into a file, and add the file.
+      $temp_file = tempnam(sys_get_temp_dir(), 'tuque');
+      $old_datastream->getContent($temp_file);
+      $this->wrapped_datastream->setContentFromFile($temp_file);
+      unlink($temp_file);
+    }
+    foreach ($properties as $property) {
+      $this->wrapped_datastream->$property = $old_datastream->$property;
+    }
+
+    $this->wrapped_datastream->logMessage = 'Datastream contents copied on write.';
+
+    //XXX: This will break if the Fedora object will actually purge the object
+    //  on an "unset"...
+    unset($this->parent[$this->wrapped_datastream->id]);
+
+    $this->parent->ingestDatastream($this->wrapped_datastream);
+  }
+
+  /**
+   * Access the wrapped datastream.
+   */
+  public function __get($name) {
+    return $this->wrapped_datastream->$name;
+  }
+
+  /**
+   * Check on the wrapped the datastream.
+   */
+  public function __isset($name) {
+    return isset($this->wrapped_datastream->{$name});
+  }
+
+  /**
+   * Get the content of the wrapped datastream.
+   */
+  public function getContent($file) {
+    return $this->wrapped_datastream->getContent($file);
+  }
+
+  /**
+   * Unset from the wrapped datastream.
+   *
+   * Will create a copy of the wrapped_datastream first.
+   */
+  public function __unset($name) {
+    if (!($this->wrapped_datastream instanceof NewFedoraDatastream)) {
+      $this->createNewDatastreamCopy();
+    }
+
+    unset($this->wrapped_datastream->{$name});
+  }
+
+  /**
+   * Set something on the wrapped datastream.
+   *
+   * Will create a copy of the wrapped_datastream first.
+   */
+  public function __set($name, $value) {
+    if (!($this->wrapped_datastream instanceof NewFedoraDatastream)) {
+      $this->createNewDatastreamCopy();
+    }
+
+    return $this->wrapped_datastream->$name = $value;
+  }
+
+  /**
+   * Set the content from a file.
+   *
+   * Will create a copy of the wrapped_datastream first.
+   * @see NewFedoraDatastream::setContentFromFile()
+   */
+  public function setContentFromFile($file, $copy = FALSE) {
+    if (!($this->wrapped_datastream instanceof NewFedoraDatastream)) {
+      $this->createNewDatastreamCopy();
+    }
+    $this->wrapped_datastream->setContentFromFile($file, $copy);
+  }
+
+  /**
+   * Set the content from a URL.
+   *
+   * Will create a copy of the wrapped_datastream first.
+   * @see NewFedoraDatastream::setContentFromUrl().
+   */
+  public function setContentFromUrl($url){
+    if (!($this->wrapped_datastream instanceof NewFedoraDatastream)) {
+      $this->createNewDatastreamCopy();
+    }
+    $this->wrapped_datastream->setContentFromUrl($url);
+  }
+
+  /**
+   * Set the content from a URL.
+   *
+   * Will create a copy of the wrapped_datastream first.
+   * @see NewFedoraDatastream::setContentFromString().
+   */
+  public function setContentFromString($string) {
+    if (!($this->wrapped_datastream instanceof NewFedoraDatastream)) {
+      $this->createNewDatastreamCopy();
+    }
+    $this->wrapped_datastream->setContentFromString($string);
+  }
+}
+

--- a/Datastream.php
+++ b/Datastream.php
@@ -1737,7 +1737,6 @@ class FedoraDatastream extends AbstractExistingFedoraDatastream implements Count
  * Wraps a FedoraDatastream; creates a NewFedoraDatastream when mutated.
  *
  * Will only maintain the latest version of the given datastream.
- * XXX: May break if any wrapped objects override the MagicPropery methods.
  */
 class CopyOnWriteFedoraDatastream extends AbstractFedoraDatastream {
   /**
@@ -1750,13 +1749,21 @@ class CopyOnWriteFedoraDatastream extends AbstractFedoraDatastream {
    * Constructor; call inherited, and store the wrapped datastream.
    *
    * @param NewFedoraObject $parent
-   *   
+   *   The object to in which this datastream (will) exist.
+   * @param AbstractFedoraDatastream $wrapped_datastream
+   *   The datastream object we are to wrap.
    */
-  public function __construct(NewFedoraObject $parent, $wrapped_datastream) {
+  public function __construct(NewFedoraObject $parent, AbstractFedoraDatastream $wrapped_datastream) {
     parent::__construct($wrapped_datastream->id, $parent, $parent->repository);
     $this->wrapped_datastream = $wrapped_datastream;
   }
 
+  /**
+   * Create a NewFedoraDatastream copy, and wrap it instead of what we had.
+   *
+   * This is necessary to avoid the possibility of changing a datastream for
+   * another object, when copying datastreams between objects.
+   */
   protected function createNewDatastreamCopy() {
     $old_datastream = $this->wrapped_datastream;
 

--- a/tests/CopyDatastreamTest.php
+++ b/tests/CopyDatastreamTest.php
@@ -50,24 +50,37 @@ class CopyDatastreamTest extends PHPUnit_Framework_TestCase {
     unlink($this->tempfile2);
   }
 
+  /**
+   * Copy an existing datastream between existing FedoraObjects.
+   */
   public function testExistingToExistingIngest() {
     $object = $this->repository->ingestObject($this->new_object);
-    $copied_datastream = $this->new_object->ingestDatastream($this->object[$this->testDsid]);
+    $copied_datastream = $object->ingestDatastream($this->object[$this->testDsid]);
 
     $this->assertNotEquals($this->object->id, $copied_datastream->parent->id, 'Datastream exists on new object.');
-    $this->object[$this->testDsid]->getContent($this->tempfile1);
-    $object[$this->testDsid]->getContent($this->tempfile2);
-    $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+
+    $this->scanProperties($this->object[$this->testDsid], $object[$this->testDsid]);
   }
 
+  /**
+   * Copy an existing datastream to a NewFedoraObject.
+   *
+   * Base case; copy an existing datastream into a NewFedoraObject, and ingest
+   * the NewFedoraObject.
+   */
   public function testBaseIngest() {
     $this->assertTrue($this->new_object->ingestDatastream($this->object[$this->testDsid]), 'Create datastream entry on new object');
     $object = $this->repository->ingestObject($this->new_object);
-    $this->object[$this->testDsid]->getContent($this->tempfile1);
-    $object[$this->testDsid]->getContent($this->tempfile2);
-    $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+
+    $this->scanProperties($this->object[$this->testDsid], $object[$this->testDsid]);
   }
 
+  /**
+   * Copy an existing datastream, triggering copy-on-write mechanism.
+   *
+   * Test the ingest of an existing datastream, introducing a change (setting
+   * the label) which should force the "copy-on-write" mechanism to fire.
+   */
   public function testCopiedIngest() {
     $this->assertTrue($this->new_object->ingestDatastream($this->object[$this->testDsid]), 'Create datastream entry on new object');
     $datastream = $this->new_object[$this->testDsid];
@@ -80,8 +93,82 @@ class CopyDatastreamTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($datastream->label, $new_label, 'New label accessible through old wrapper.');
     $object = $this->repository->ingestObject($this->new_object);
 
-    $this->object[$this->testDsid]->getContent($this->tempfile1);
-    $object[$this->testDsid]->getContent($this->tempfile2);
-    $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+    $this->scanProperties($this->object[$this->testDsid], $object[$this->testDsid], array(
+      'label' => $new_label,
+    ));
+  }
+
+  /**
+   * Compare all properties on the given datastreams.
+   *
+   * Compares two instances of a datastream for similarity.
+   *
+   * @param AbstractDatastream $alpha
+   *   A datastream to compare.
+   * @param AbstractDatastream $bravo
+   *   Another datastream, possibly with the changes listed in $changed
+   *   differentiating it from $alpha.
+   * @param array $changed
+   *   An array of ways in which the properties of $bravo vary from $alpha,
+   *   mapping from properties names to the values on $bravo. Changes to the
+   *   'content' property should reference a filename (not $this->tempfile1).
+   */
+  protected function scanProperties(AbstractDatastream $alpha, AbstractDatastream $bravo, array $changed = array()) {
+    $this->assertNotSame($alpha, $bravo, 'Datastreams being compared are not the same object.');
+
+    $properties = array(
+      'id',
+      'label',
+      'controlGroup',
+      'versionable',
+      'state',
+      'mimetype',
+      'format',
+      // Size is related to the content...
+      //'size',
+      'checksum',
+      'checksumType',
+      // createdDate is not copied.
+      //'createdDate',
+      // Content is tested separately, using getContent().
+      //'content',
+      // location is different by definition, since we require the objects
+      // to be different, and the location contains the object's PID.
+      //'location',
+      // Log message is not expected to be the same...
+      //'logMessage',
+    );
+
+    $similar_properties = array_diff($properties, array_keys($changed));
+
+    foreach ($similar_properties as $property) {
+      $this->assertEquals($alpha->$property, $bravo->$property, "'$property' is equal.");
+    }
+    foreach ($changed as $property => $value) {
+      $message = "New value of '$property' is present.";
+      if ($property == 'content') {
+        $bravo->getContent($this->tempfile1);
+        $this->assertFileEquals($this->tempfile1, $value, $message);
+      }
+      else {
+        $this->assertEquals($bravo->$property, $value, $message);
+      }
+    }
+
+    $gettable_control_groups = array('X', 'M');
+    if (!array_key_exists('content', $changed)
+      && in_array($alpha->controlGroup, $gettable_control_groups)
+      && in_array($bravo->controlGroup, $gettable_control_groups)) {
+
+      $alpha->getContent($this->tempfile1);
+      $bravo->getContent($this->tempfile2);
+      $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+    }
+    elseif (!array_key_exists('url', $changed)
+      && in_array($alpha->controlGroup, $gettable_control_groups)
+      && in_array($bravo->controlGroup, $gettable_control_groups)) {
+      $this->assertEquals($alpha->url, $bravo->url, 'Datastream URLs are equal.');
+    }
   }
 }
+

--- a/tests/CopyDatastreamTest.php
+++ b/tests/CopyDatastreamTest.php
@@ -1,0 +1,87 @@
+<?php
+
+require_once 'Datastream.php';
+require_once 'FedoraApi.php';
+require_once 'FedoraApiSerializer.php';
+require_once 'Object.php';
+require_once 'Repository.php';
+require_once 'Cache.php';
+require_once 'TestHelpers.php';
+
+class CopyDatastreamTest extends PHPUnit_Framework_TestCase {
+
+  protected function setUp() {
+    $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);
+    $this->api = new FedoraApi($connection);
+    $cache = new SimpleCache();
+    $this->repository = new FedoraRepository($this->api, $cache);
+
+    // create an object
+    $string1 = FedoraTestHelpers::randomString(10);
+    $string2 = FedoraTestHelpers::randomString(10);
+    $this->testPid = "$string1:$string2";
+    $this->api->m->ingest(array('pid' => $this->testPid));
+
+
+    $string3 = FedoraTestHelpers::randomString(10);
+    $string4 = FedoraTestHelpers::randomString(10);
+    $this->testPid2 = "$string3:$string4";
+    $this->new_object = $this->repository->constructObject();
+    $this->new_object->id = $this->testPid2;
+    $this->new_object->label = 'Sommat';
+    $this->new_object->owner = 'us';
+
+    // create a DSID
+    $this->testDsid = FedoraTestHelpers::randomCharString(10);
+    $this->testDsContents = '<test><xml/></test>';
+    $this->api->m->addDatastream($this->testPid, $this->testDsid, 'string', $this->testDsContents, array('controlGroup' => 'M'));
+    $this->object = new FedoraObject($this->testPid, $this->repository);
+    $this->ds = new FedoraDatastream($this->testDsid, $this->object, $this->repository);
+
+    $temp_dir = sys_get_temp_dir();
+    $this->tempfile1 = tempnam($temp_dir, 'test');
+    $this->tempfile2 = tempnam($temp_dir, 'test');
+  }
+
+  protected function tearDown() {
+    $this->api->m->purgeObject($this->testPid);
+    $this->api->m->purgeObject($this->testPid2);
+    unlink($this->tempfile1);
+    unlink($this->tempfile2);
+  }
+
+  public function testExistingToExistingIngest() {
+    $object = $this->repository->ingestObject($this->new_object);
+    $copied_datastream = $this->new_object->ingestDatastream($this->object[$this->testDsid]);
+
+    $this->assertNotEquals($this->object->id, $copied_datastream->parent->id, 'Datastream exists on new object.');
+    $this->object[$this->testDsid]->getContent($this->tempfile1);
+    $object[$this->testDsid]->getContent($this->tempfile2);
+    $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+  }
+
+  public function testBaseIngest() {
+    $this->assertTrue($this->new_object->ingestDatastream($this->object[$this->testDsid]), 'Create datastream entry on new object');
+    $object = $this->repository->ingestObject($this->new_object);
+    $this->object[$this->testDsid]->getContent($this->tempfile1);
+    $object[$this->testDsid]->getContent($this->tempfile2);
+    $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+  }
+
+  public function testCopiedIngest() {
+    $this->assertTrue($this->new_object->ingestDatastream($this->object[$this->testDsid]), 'Create datastream entry on new object');
+    $datastream = $this->new_object[$this->testDsid];
+    $this->assertTrue($datastream instanceof CopyOnWriteFedoraDatastream, 'Datastream is a COW.');
+
+    $new_label = strrev($this->new_object[$this->testDsid]->label);
+    $new_label .= $new_label;
+
+    $this->new_object[$this->testDsid]->label = $new_label;
+    $this->assertEquals($datastream->label, $new_label, 'New label accessible through old wrapper.');
+    $object = $this->repository->ingestObject($this->new_object);
+
+    $this->object[$this->testDsid]->getContent($this->tempfile1);
+    $object[$this->testDsid]->getContent($this->tempfile2);
+    $this->assertFileEquals($this->tempfile1, $this->tempfile2, 'Datastream contents are equal.');
+  }
+}


### PR DESCRIPTION
Can now (safely) ingest existing datastreams into a NewFedoraObject.

A mutation to the datastream before the ingest of the NewFedoraObject will result in a copy of the datastream being created, so the original datastream does not get affected.
