### PR TITLE
Add a method for counting the number of tuples a query returns.

### DIFF
--- a/tests/RepositoryQueryTest.php
+++ b/tests/RepositoryQueryTest.php
@@ -30,6 +30,6 @@ where $pid <fedora-model:label> $label';
     $results = count($this->repository->ri->itqlQuery($query));
     $number = $this->repository->ri->countQuery($query, 'itql');
 
-    $this->assertEqual($results, $number, 'The number of tuples returned was equal.');
+    $this->assertEquals($results, $number, 'The number of tuples returned was equal.');
   }
 }

--- a/tests/RepositoryQueryTest.php
+++ b/tests/RepositoryQueryTest.php
@@ -21,6 +21,15 @@ class RepositoryQueryTest extends PHPUnit_Framework_TestCase {
     $query = 'select $pid $label from <#ri>
 where $pid <fedora-model:label> $label';
     $results = $this->repository->ri->itqlQuery($query);
-    $this->assertTrue(TRUE);
+    $this->pass('The query did not throw an exception.');
+  }
+
+  public function testCount() {
+    $query = 'select $pid $label from <#ri>
+where $pid <fedora-model:label> $label';
+    $results = count($this->repository->ri->itqlQuery($query));
+    $number = $this->repository->ri->countQuery($query, 'itql');
+
+    $this->assertEqual($results, $number, 'The number of tuples returned was equal.');
   }
 }

--- a/tests/RepositoryQueryTest.php
+++ b/tests/RepositoryQueryTest.php
@@ -21,7 +21,7 @@ class RepositoryQueryTest extends PHPUnit_Framework_TestCase {
     $query = 'select $pid $label from <#ri>
 where $pid <fedora-model:label> $label';
     $results = $this->repository->ri->itqlQuery($query);
-    $this->pass('The query did not throw an exception.');
+    $this->assertTrue(TRUE, 'The query did not throw an exception.');
   }
 
   public function testCount() {


### PR DESCRIPTION
Sparql in particular doesn't have a built-in counting construct; therefore,
a helper method is desirable to facilitate paging and the like.
