### PR TITLE
Windows-compatibility: Problems with php:// I/O streams

### DIFF
--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -583,8 +583,7 @@ class CurlConnection extends HttpConnection {
         // occurs when trying to ingest a page into the Book Solution Pack:
         // "Warning: curl_setopt(): cannot represent a stream of type 
         //  MEMORY as a STDIO FILE* in CurlConnection->putRequest()"
-        $file_stream = (((strtolower(substr(PHP_OS, 0, 3)) == 'win') ||
-                         (strtolower(substr(PHP_OS, 0, 6)) == 'cygwin')) ? 'php://temp' : 'php://memory');
+        $file_stream = ((strpos(strtolower(php_uname('s')), 'windows') !== FALSE) ? 'php://temp' : 'php://memory');
         $fh = fopen($file_stream, 'rw');
         fwrite($fh, $file);
         rewind($fh);
@@ -671,8 +670,7 @@ class CurlConnection extends HttpConnection {
       $file = fopen($file, 'w+');
       // Determine if the current operating system is Windows.
       // Also check whether the output buffer is being utilized.
-      if (((strtolower(substr(PHP_OS, 0, 3)) == 'win') ||
-           (strtolower(substr(PHP_OS, 0, 6)) == 'cygwin')) &&
+      if ((strpos(strtolower(php_uname('s')), 'windows') !== FALSE) &&
           ($file_original_path == 'php://output')) {
         // In Windows, ensure the image can be displayed onscreen. Just using
         // 'CURLOPT_FILE' results in a broken image and the following error:

--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -297,6 +297,20 @@ class CurlConnection extends HttpConnection {
   }
 
   /**
+   * Determines if the server operating system is Windows.
+   *
+   * @return bool
+   *   TRUE if Windows, FALSE otherwise.
+   */
+  public function isWindows() {
+    // Determine if PHP is currently running on Windows.
+    if (strpos(strtolower(php_uname('s')), 'windows') !== FALSE) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Create a file to store cookies.
    */
   protected function createCookieFile() {
@@ -583,7 +597,7 @@ class CurlConnection extends HttpConnection {
         // occurs when trying to ingest a page into the Book Solution Pack:
         // "Warning: curl_setopt(): cannot represent a stream of type 
         //  MEMORY as a STDIO FILE* in CurlConnection->putRequest()"
-        $file_stream = ((strpos(strtolower(php_uname('s')), 'windows') !== FALSE) ? 'php://temp' : 'php://memory');
+        $file_stream = (($this->isWindows()) ? 'php://temp' : 'php://memory');
         $fh = fopen($file_stream, 'rw');
         fwrite($fh, $file);
         rewind($fh);
@@ -670,8 +684,7 @@ class CurlConnection extends HttpConnection {
       $file = fopen($file, 'w+');
       // Determine if the current operating system is Windows.
       // Also check whether the output buffer is being utilized.
-      if ((strpos(strtolower(php_uname('s')), 'windows') !== FALSE) &&
-          ($file_original_path == 'php://output')) {
+      if (($this->isWindows()) && ($file_original_path == 'php://output')) {
         // In Windows, ensure the image can be displayed onscreen. Just using
         // 'CURLOPT_FILE' results in a broken image and the following error:
         // "Warning: curl_setopt(): cannot represent a stream of type

--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -302,7 +302,7 @@ class CurlConnection extends HttpConnection {
    * @return bool
    *   TRUE if Windows, FALSE otherwise.
    */
-  public function isWindows() {
+  protected function isWindows() {
     // Determine if PHP is currently running on Windows.
     if (strpos(strtolower(php_uname('s')), 'windows') !== FALSE) {
       return TRUE;
@@ -592,11 +592,11 @@ class CurlConnection extends HttpConnection {
     curl_setopt(self::$curlContext, CURLOPT_CUSTOMREQUEST, 'PUT');
     switch (strtolower($type)) {
       case 'string':
-        // Updated: slangerx, 2013-12-26; Reference: http://bit.ly/18Qym02
         // When using 'php://memory' in Windows, the following error
         // occurs when trying to ingest a page into the Book Solution Pack:
         // "Warning: curl_setopt(): cannot represent a stream of type 
-        //  MEMORY as a STDIO FILE* in CurlConnection->putRequest()"
+        // MEMORY as a STDIO FILE* in CurlConnection->putRequest()"
+        // Reference: http://bit.ly/18Qym02
         $file_stream = (($this->isWindows()) ? 'php://temp' : 'php://memory');
         $fh = fopen($file_stream, 'rw');
         fwrite($fh, $file);
@@ -675,7 +675,6 @@ class CurlConnection extends HttpConnection {
     }
 
     if ($file) {
-      // Updated: slangerx: 2013-09-09;
       $file_original_path = $file;
       // In Windows, using 'temporary://' with curl_setopt 'CURLOPT_FILE'
       // results in the following error: "Warning: curl_setopt():


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

Windows seems to have a problem with some of the php:// I/O streams in this library, resulting in a flurry of Drupal error messages, such as:
-  `Warning: curl_setopt(): DrupalTemporaryStreamWrapper::stream_cast is not implemented!`
-  `Warning: curl_setopt(): cannot represent a stream of type Output as a STDIO FILE* in CurlConnection->getRequest()` [[Resource](http://www.php.net/manual/en/function.curl-setopt.php#58074)]
-  `Warning: curl_setopt(): cannot represent a stream of type MEMORY as a STDIO FILE* in CurlConnection->putRequest()` [[Resource](http://bit.ly/18Qym02)]

This patch attempts to correct that. Read the PHP comments for more information.

_NOTE:_ It might be more efficient to create a function that is called whenever OS detection is required (similar to https://github.com/Islandora/islandora/pull/450); but I had trouble getting that to work in this case.
