### PR TITLE
Fixes ISLANDORA-1199

### DIFF
--- a/RepositoryQuery.php
+++ b/RepositoryQuery.php
@@ -26,7 +26,7 @@ class RepositoryQuery {
    * Parse the passed in Sparql XML string into a more easily usable format.
    *
    * @param string $sparql
-   *   A string containing Sparql result XML. Currently only handles pure Sparql XML, but not Sparql_W3C
+   *   A string containing Sparql result XML.
    *
    * @return array
    *   Indexed (numerical) array, containing a number of associative arrays,
@@ -62,9 +62,7 @@ class RepositoryQuery {
           $val['type'] = 'pid';
         }
         else {
-          // @TODO Should avoid storing not bound variables/elements?, means those 
-          // with attribute bound="false". Standard SPARQL_W3C does not return unbound variables,
-          // but implementing this on current results could break existing code.
+          //deal with any other types
           $val['type'] = 'literal';
           $val['value'] = (string) $xmlReader->readInnerXML();
         }

--- a/RepositoryQuery.php
+++ b/RepositoryQuery.php
@@ -26,7 +26,7 @@ class RepositoryQuery {
    * Parse the passed in Sparql XML string into a more easily usable format.
    *
    * @param string $sparql
-   *   A string containing Sparql result XML.
+   *   A string containing Sparql result XML. Currently only handles pure Sparql XML, but not Sparql_W3C
    *
    * @return array
    *   Indexed (numerical) array, containing a number of associative arrays,
@@ -35,36 +35,44 @@ class RepositoryQuery {
    *   off, to facilitate their use as PIDs.
    */
   public static function parseSparqlResults($sparql) {
-    // Load the results into a SimpleXMLElement.
-    $doc = new SimpleXMLElement($sparql, 0, FALSE, self::SIMPLE_XML_NAMESPACE);
-
+    // Load the results into a XMLReader Object.
+    $xmlReader = new XMLReader();
+    $xmlReader->xml($sparql);
+    
     // Storage.
     $results = array();
     // Build the results.
-    foreach ($doc->results->children() as $result) {
-      // Built a single result.
-      $r = array();
-      foreach ($result->children() as $element) {
+    while ($xmlReader->read()) {
+      if ($xmlReader->localName === 'result') {
+        if ($xmlReader->nodeType == XMLReader::ELEMENT) {
+          // Initialize a single result.
+          $r = array();
+        }
+        elseif ($xmlReader->nodeType == XMLReader::END_ELEMENT) {
+          // Add result to results
+          $results[] = $r;
+        }
+      }
+      elseif ($xmlReader->nodeType == XMLReader::ELEMENT && $xmlReader->depth == 3) {
         $val = array();
-
-        $attrs = $element->attributes();
-        if (!empty($attrs['uri'])) {
-          $val['value'] = self::pidUriToBarePid((string) $attrs['uri']);
-          $val['uri'] = (string) $attrs['uri'];
+        $uri = $xmlReader->getAttribute('uri');
+        if ($uri !== NULL) {
+          $val['value'] = self::pidUriToBarePid($uri);
+          $val['uri'] = (string) $uri;
           $val['type'] = 'pid';
         }
         else {
+          // @TODO Should avoid storing not bound variables/elements?, means those 
+          // with attribute bound="false". Standard SPARQL_W3C does not return unbound variables,
+          // but implementing this on current results could break existing code.
           $val['type'] = 'literal';
-          $val['value'] = (string) $element;
+          $val['value'] = (string) $xmlReader->readInnerXML();
         }
-
-        // Map the name to the value in the array.
-        $r[$element->getName()] = $val;
+        $r[$xmlReader->localName] = $val;
       }
-
-      // Add the single result to the set to return.
-      $results[] = $r;
     }
+
+    $xmlReader->close();
     return $results;
   }
 


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/ISLANDORA-1199
Large SPARQL XML results would consume all PHP memory when using
SimpleXML and foreach combination. By using xmlReader, memory
consumption is minimum. Existing functionality/structure was preserved to avoid breaking code.
