### PR TITLE
ISLANDORA-1281 Resource Index and Tab character

### DIFF
--- a/RepositoryConnection.php
+++ b/RepositoryConnection.php
@@ -94,7 +94,8 @@ class RepositoryConnection extends CurlConnection implements RepositoryConfigInt
   /**
    * This function adds a specific parameter to a RESTful request. It makes
    * sure that PHP booleans are changes into true and false and that the
-   * parameters are properly URL encoded.
+   * parameters's special space characters are replaced/trimmed and properly
+   * URL encoded.
    *
    * @param string $request
    *   The request that is being built.
@@ -112,6 +113,7 @@ class RepositoryConnection extends CurlConnection implements RepositoryConfigInt
         $parameter = $value ? 'true' : 'false';
       }
       else {
+        $value = trim(preg_replace('/[\x00-\x20]+/', ' ', $value));
         $parameter = urlencode($value);
       }
       $request .= "{$seperator}{$name}={$parameter}";


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1281

Replace special space characters (x00-x20) from parameters send to
Fedora's API.

Resolves tabs, carriage returns, other space chars to avoid problems
with how Fedora handles, e.g, adding/removing ResourceIndex Tripples
when those are present. Extends the particular fix to every parameter 
passed to Fedora's api
