### PR TITLE
Tuque 1.7 and 32-bit PHP: Can't ingest files over 2GB

### DIFF
--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -311,6 +311,46 @@ class CurlConnection extends HttpConnection {
   }
 
   /**
+   * Returns the file size (in bytes) as a string (for 32-bit PHP).
+   *
+   * 32-bit PHP can't handle file sizes larger than 2147483647 bytes (2.15GB),
+   * since that's the PHP_INT_MAX. In order to compensate, this function
+   * uses exec() to retrieve the file size from the operating system and return
+   * it as a string. Note that converting the value back into an integer
+   * will reintroduce the same max-integer problems.
+   *
+   * Based on the function sizeExec() from https://github.com/jkuchar/BigFileTools
+   *
+   * @return string | bool (FALSE upon failure or when exec() is disabled)
+   */
+  protected function filesize_php32bit($file) {
+    $disabled_functions = explode(',', ini_get('disable_functions'));
+
+    // Ensure PHP is capable of executing an external program.
+    if ((function_exists("exec")) || (!in_array('exec', $disabled_functions))) {
+
+      $file = drupal_realpath($file);
+      $escaped_path = escapeshellarg($file);
+
+      if ($this->isWindows()) {
+        // Use a Windows command to find the file size.
+        $size = trim(exec("for %F in ($escaped_path) do @echo %~zF"));
+      }
+      else {
+        // Otherwise, use the stat command (*nix and MacOS).
+        $size = trim(exec("stat -Lc%s $escaped_path"));
+      }
+
+      // Ensure a number was returned.
+      if ($size AND ctype_digit($size)) {
+        // Return the file size as a string.
+        return (string) $size;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Create a file to store cookies.
    */
   protected function createCookieFile() {
@@ -615,9 +655,27 @@ class CurlConnection extends HttpConnection {
       case 'file':
         $fh = fopen($file, 'r');
         $size = filesize($file);
+        // Determine if this is 32-bit PHP (based on the integer size).
+        if (PHP_INT_SIZE === 4) {
+          // Retrieve the file size as a string.
+          $size = $this->filesize_php32bit($file);
+          if ($size !== FALSE) {
+            // When the file size is set using CURLOPT_INFILESIZE, the value
+            // is automatically converted into an integer. Unfortunately,
+            // 32-bit PHP can't handle file sizes (in bytes) larger than
+            // 2.15GB. To get around this, update the cURL header directly
+            // instead. The size remains a string when added to the header.
+            // cURL is then able to process the file correctly later on.
+            curl_setopt(self::$curlContext, CURLOPT_HTTPHEADER, array(
+              'Content-Length: ' . $size,
+            ));
+          }
+        }
+        else {
+          curl_setopt(self::$curlContext, CURLOPT_INFILESIZE, $size);
+        }
         curl_setopt(self::$curlContext, CURLOPT_PUT, TRUE);
         curl_setopt(self::$curlContext, CURLOPT_INFILE, $fh);
-        curl_setopt(self::$curlContext, CURLOPT_INFILESIZE, $size);
         break;
 
       case 'none':


### PR DESCRIPTION
**The Problem**
For anyone using 32-bit PHP, files over 2GB can't be successfully ingested into Islandora.

The obvious solution is to simply not use 32-bit PHP. Unfortunately for Windows-users, even when you download a 64-bit version of PHP, the underlying C-code still treats integers as 32-bit. (From windows.php.net: "The x64 builds of PHP 5 for Windows... do not provide 64-bit integer or large file support.") 32-bit PHP can't handle file sizes larger than 2147483647 bytes (2.15GB), since that exceeds the PHP_INT_MAX.

The Tuque library uses the PHP function <a href="http://php.net/manual/en/function.filesize.php">filesize()</a>, which documents this 32-bit problem as well: "Because PHP's integer type is signed and many platforms use 32bit integers, some filesystem functions may return unexpected results for files which are larger than 2GB." 

Of course, there are other ways to find the file size -- and that number could even be returned as a string. However, the moment that value is added to curl_setopt() (with the option CURLOPT_INFILESIZE), it will automatically be converted into an integer, reintroducing the 32-bit problem. Files larger than 2GB will be unexpectedly assigned a size _smaller_ than PHP_INT_MAX and only a portion of the file will end up getting ingested into Islandora.

**The Solution**
For 32-bit PHP users, don't assign the file size using CURLOPT_INFILESIZE. Instead, update the cURL header directly (CURLOPT_HTTPHEADER; Content-Length:...). By doing that, the file size remains a string when it is added to the header and doesn't get transformed into an integer. cURL is then able to use that information correctly later on and successfully ingest the entire object.

This pull request includes a new function that retrieves the file size for 32-bit PHP users, as well as logic for deciding when to use CURLOPT_INFILESIZE and when to use CURLOPT_HTTPHEADER. Additional information can be found in the post "<a href="https://groups.google.com/d/msg/islandora/LFtUaa8wqDU/Z-8rXnXmCwAJ">Video Ingest: File Size Limit</a>."
