### PR TITLE
Ensure `putRequest()` uses fresh `stat()` data.

### DIFF
--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -653,6 +653,7 @@ class CurlConnection extends HttpConnection {
         break;
 
       case 'file':
+        clearstatcache(TRUE, $file);
         $fh = fopen($file, 'r');
         $size = filesize($file);
         // Determine if this is Windows, plus 32-bit PHP (based on the integer size).


### PR DESCRIPTION
**Jira:** [ISLANDORA-1631](https://jira.duraspace.org/browse/ISLANDORA-1631)
# What does this Pull Request do?

Flushes PHP's stat cache for files being `PUT`, so we are sure to obtain (and provide) the correct filesize, to ensure datastream modifications can be made correctly.
# How should this be tested?

This was initially identified in relation to regenerating HOCR; however, it could be made to happen artificially with something like:

``` php
$object = islandora_object_load('islandora:root');
$dsid = 'TEST';
$ds = isset($object[$dsid]) ? $object[$dsid] : $object->constructDatastream('TEST', 'M');
$file = file_create_filename('temp', 'temporary://');
$file = drupal_realpath($file);
file_put_contents($file, 'a super long string');
$initial = filesize($file);
$ds->setContentFromFile($file);

if (!isset($object[$dsid])) {
  $ds->mimetype = 'text/plain';
  $ds = $object->ingestDatastream($ds);
}

$f = fopen($file, 'r+');
$later = filesize($file);
fseek($f, 0);
ftruncate($f, 0);
fwrite($f, 'shorter one');
fclose($f);

// Should fail, before this PR with Drupal >= 7.42.
$object[$dsid]->setContentFromFile($file);

dsm($initial, 'initial');
dsm($later, 'later');
```
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @willtp87 @DiegoPino 

---

Adam Vessey
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
