### PR TITLE
Using a strict check to avoid hitting the nesting limit as seen on PHP 5.5.9

### DIFF
--- a/Object.php
+++ b/Object.php
@@ -559,7 +559,7 @@ class NewFedoraObject extends AbstractFedoraObject {
     if (!isset($this->datastreams[$ds->id])) {
       // The datastream does not already belong to this object, aka was created
       // by this object.
-      if ($ds->parent != $this) {
+      if ($ds->parent !== $this) {
         // Create a NewFedoraDatastream copy.
         $this->createNewDatastreamCopy($ds);
       }


### PR DESCRIPTION
**Jira:** [ISLANDORA-1636](https://jira.duraspace.org/browse/ISLANDORA-1636)
# What does this Pull Request do?

This change moves to a strict equality check to prevent recursion through the object during attribute comparison on some versions of PHP.
# How should this be tested?

Apply fix.
Try to enable solution packs on PHP 5.5.9.
Enable succeeds.
# Background context:

When trying to enable modules an error was generated. This was on a more advanced PHP than usual (PHP 5.5.9):

PHP Fatal error: Nesting level too deep - recursive dependency? in ...libraries/tuque/Object.php on line 562

---

William Panting
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
