### PR TITLE
Set license in composer to same as LICENSE; Address ISLANDORA-1701.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "islandora/tuque",
   "description": "A PHP API for connecting to the Fedora Commons repository software.",
   "homepage": "http://islandora.ca",
-  "license": "GPL-2.0+",
+  "license": "GPLv3",
   "require": {
     "php": ">=5.3.0",
     "lib-curl": "*",


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1701
# What does this Pull Request do?

Sets the license in `composer.json` to the same as the LICENSE file.
# What's new?

Consistency in licensing.
# How should this be tested?

Look at LICENSE file and then look at `composer.json`.
# Interested parties

@qadan @willtp87 @DiegoPino @manez 

See also: #143
