### PR TITLE
Retries now send the file correctly.

### DIFF
--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -443,7 +443,7 @@ class CurlConnection extends HttpConnection {
    * @return array
    *   Array has keys: (status, headers, content).
    */
- protected function doCurlRequest($file = NULL) {
+ protected function doCurlRequest($file = NULL, $file_handle = NULL) {
     $remaining_attempts = 3;
     while ($remaining_attempts > 0) {
       $curl_response = curl_exec(self::$curlContext);
@@ -476,6 +476,9 @@ class CurlConnection extends HttpConnection {
       }
       $blocked = $info['http_code'] == 409;
       $remaining_attempts = $blocked ? --$remaining_attempts : 0;
+      if (!is_null($file_handle)) {
+        rewind($file_handle);
+      }
     }
     // Throw an exception if this isn't a 2XX response.
     $success = preg_match("/^2/", $info['http_code']);
@@ -689,7 +692,7 @@ class CurlConnection extends HttpConnection {
     // Ugly substitute for a try catch finally block.
     $exception = NULL;
     try {
-      $results = $this->doCurlRequest();
+      $results = $this->doCurlRequest(NULL, $fh);
     } catch (HttpConnectionException $e) {
       $exception = $e;
     }

--- a/HttpConnection.php
+++ b/HttpConnection.php
@@ -692,7 +692,7 @@ class CurlConnection extends HttpConnection {
     // Ugly substitute for a try catch finally block.
     $exception = NULL;
     try {
-      $results = $this->doCurlRequest(NULL, $fh);
+      $results = isset($fh) ? $this->doCurlRequest(NULL, $fh) : $this->doCurlRequest(NULL);
     } catch (HttpConnectionException $e) {
       $exception = $e;
     }

--- a/tests/DatastreamTest.php
+++ b/tests/DatastreamTest.php
@@ -331,7 +331,7 @@ foo;
    * open references to the same object.  This should be investigated.
    *
    * @expectedException        RepositoryException
-   * @expectedExceptionCode 500
+   * @expectedExceptionCode 409
    */
   public function testLocking() {
     $ds1 = new FedoraDatastream($this->testDsid, $this->object, $this->repository);


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1901](https://jira.duraspace.org/browse/ISLANDORA-1901)

# What does this Pull Request do?

Prevent timeouts in the event `PUT` requests fail due to spurious HTTP 409 Conflict errors.

# What's new?

Rewind the file handle when retrying.

# How should this be tested?

Regression testing is about it... Spurious issues are spurious.

I've not yet actually tried, but I believe the timeout behaviour described in the ticket can be forced by making bad requests... which is to say, making a request with old last modified dates, resulting in an _actual_ 409... So this PR would fail faster, avoiding the timeouts at least.

# Additional Notes:
* Does this change require documentation to be updated?  No.
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# Interested parties

Maintainers: @DiegoPino and @willtp87 
