### PR TITLE
Update to use namespaced PHPunit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 php:
+  - 5.3
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -8,8 +11,9 @@ env:
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
 before_script:
+  - composer install
   - $TRAVIS_BUILD_DIR/tests/scripts/travis_setup.sh
 script:
-  - phpunit -c tests/travis.xml tests/
+  - vendor/bin/phpunit -c tests/travis.xml tests/
 notifications:
   irc: "irc.freenode.org#islandora"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: php
 php:
-  - "5.3"
-  - "5.4"
-  - "5.5"
+  - 5.6
+  - 7.0
+  - 7.1
 env:
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
-# broken right now, should be fixed
-#  - FEDORA_VERSION="3.5"
 before_script:
   - $TRAVIS_BUILD_DIR/tests/scripts/travis_setup.sh
 script:

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": ">=5.3.0",
     "lib-curl": "*",
-    "lib-xml": "*"
+    "lib-libxml": "*",
+    "phpunit/phpunit": ">=4.8.35|>=5.4.3.,<=5.0"
   }
 }

--- a/tests/ApiUploadTest.php
+++ b/tests/ApiUploadTest.php
@@ -1,7 +1,9 @@
 <?php
 require_once 'TestHelpers.php';
 
-class UploadTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class UploadTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,7 +1,9 @@
 <?php
 require_once "Cache.php";
 
-class SimpleCacheTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class SimpleCacheTest extends TestCase {
 
   function testAdd() {
     SimpleCache::resetCache();

--- a/tests/CopyDatastreamTest.php
+++ b/tests/CopyDatastreamTest.php
@@ -8,7 +8,9 @@ require_once 'Repository.php';
 require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
-class CopyDatastreamTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class CopyDatastreamTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/DatastreamTest.php
+++ b/tests/DatastreamTest.php
@@ -8,7 +8,9 @@ require_once 'Repository.php';
 require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
-class DatastreamTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class DatastreamTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/FedoraApiTest.php
+++ b/tests/FedoraApiTest.php
@@ -9,7 +9,9 @@ require_once 'FedoraApiSerializer.php';
 require_once 'TestHelpers.php';
 require_once 'FedoraDate.php';
 
-class FedoraApiIngestTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class FedoraApiIngestTest extends TestCase {
   protected $pids = array();
   protected $files = array();
 
@@ -230,7 +232,7 @@ FOXML;
 }
 
 
-class FedoraApiFindObjectsTest extends PHPUnit_Framework_TestCase {
+class FedoraApiFindObjectsTest extends TestCase {
 
   public $apim;
   public $apia;

--- a/tests/FedoraDateTest.php
+++ b/tests/FedoraDateTest.php
@@ -1,7 +1,9 @@
 <?php
 require_once "FedoraDate.php";
 
-class FedoraDateTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class FedoraDateTest extends TestCase {
 
   function testToString() {
     $date = new FedoraDate("2012-03-13T19:15:07.529Z");

--- a/tests/FedoraRelationshipsExternalTest.php
+++ b/tests/FedoraRelationshipsExternalTest.php
@@ -8,7 +8,9 @@ require_once 'Repository.php';
 require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
-class FedoraRelationshipsExternalTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class FedoraRelationshipsExternalTest extends TestCase {
 
   function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/FedoraRelationshipsInternalTest.php
+++ b/tests/FedoraRelationshipsInternalTest.php
@@ -1,7 +1,9 @@
 <?php
 require_once "FedoraRelationships.php";
 
-class FedoraRelationshipsInternalTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class FedoraRelationshipsInternalTest extends TestCase {
 
   function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/FedoraRelationshipsTest.php
+++ b/tests/FedoraRelationshipsTest.php
@@ -7,7 +7,9 @@ require_once "FedoraRelationships.php";
  * @todo remove any calls to StringEqualsXmlString because it uses the
  *  domdocument cannonicalization function that doesn't work properly on cent
  */
-class FedoraRelationshipsTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class FedoraRelationshipsTest extends TestCase {
 
   function testAutoCommit() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/FoxmlDocumentTest.php
+++ b/tests/FoxmlDocumentTest.php
@@ -8,7 +8,9 @@ require_once 'Cache.php';
 require_once 'TestHelpers.php';
 require_once 'FoxmlDocument.php';
 
-class FoxmlDocumentTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class FoxmlDocumentTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/HttpConnectionTest.php
+++ b/tests/HttpConnectionTest.php
@@ -1,7 +1,9 @@
 <?php
 require_once "HttpConnection.php";
 
-class HttpConnectionTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class HttpConnectionTest extends TestCase {
 
   protected function setUp() {
     $this->xml = <<<foo

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -11,7 +11,8 @@ require_once 'TestHelpers.php';
 use \PHPUnit\Framework\TestCase;
 use \PHPUnit\Framework\Error\Error;
 
-// XXX: PHPUnit6 moved the location of the Error class.
+// XXX: PHPUnit6 moved the location of the Error class. 
+// This can be dropped when we drop support for PHP < 7.0 in our testing.
 if (class_exists('\PHPUnit\Framework\Error\Error', TRUE)) {
   class_alias('\PHPUnit\Framework\Error\Error', 'PHPUnit_Framework_Error');
 }

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -9,7 +9,12 @@ require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
 use \PHPUnit\Framework\TestCase;
-use \PHPUnit\Framework\Error;
+use \PHPUnit\Framework\Error\Error;
+
+// XXX: PHPUnit6 moved the location of the Error class.
+if (class_exists('\PHPUnit\Framework\Error\Error', TRUE)) {
+  class_alias('\PHPUnit\Framework\Error\Error', 'PHPUnit_Framework_Error');
+}
 
 class NewDatastreamTest extends TestCase {
 
@@ -36,7 +41,7 @@ class NewDatastreamTest extends TestCase {
   }
 
   /**
-   * @expectedException Error
+   * @expectedException PHPUnit_Framework_Error
    */
   public function testConstructor() {
     $x = new NewFedoraDatastream('foo', 'zap', $this->object, $this->repository);
@@ -54,14 +59,14 @@ class NewDatastreamTest extends TestCase {
   }
 
   /**
-   * @expectedException Error
+   * @expectedException PHPUnit_Framework_Error
    */
   public function testUnsetControlGroup() {
     unset($this->x->controlGroup);
   }
 
   /**
-   * @expectedException Error
+   * @expectedException PHPUnit_Framework_Error
    */
   public function testSetControlGroup() {
     $this->x->controlGroup = 'M';

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -8,7 +8,9 @@ require_once 'Repository.php';
 require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
-class NewDatastreamTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class NewDatastreamTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -9,6 +9,7 @@ require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
 use \PHPUnit\Framework\TestCase;
+use \PHPUnit\Framework\Error;
 
 class NewDatastreamTest extends TestCase {
 
@@ -35,7 +36,7 @@ class NewDatastreamTest extends TestCase {
   }
 
   /**
-   * @expectedException PHPUnit_Framework_Error
+   * @expectedException Error
    */
   public function testConstructor() {
     $x = new NewFedoraDatastream('foo', 'zap', $this->object, $this->repository);
@@ -53,14 +54,14 @@ class NewDatastreamTest extends TestCase {
   }
 
   /**
-   * @expectedException PHPUnit_Framework_Error
+   * @expectedException Error
    */
   public function testUnsetControlGroup() {
     unset($this->x->controlGroup);
   }
 
   /**
-   * @expectedException PHPUnit_Framework_Error
+   * @expectedException Error
    */
   public function testSetControlGroup() {
     $this->x->controlGroup = 'M';

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -7,7 +7,9 @@ require_once 'Repository.php';
 require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
-class ObjectTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class ObjectTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/RepositoryQueryTest.php
+++ b/tests/RepositoryQueryTest.php
@@ -8,7 +8,9 @@ require_once 'TestHelpers.php';
 require_once 'RepositoryConnection.php';
 require_once 'FedoraApi.php';
 
-class RepositoryQueryTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class RepositoryQueryTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -8,7 +8,9 @@ require_once 'TestHelpers.php';
 require_once 'RepositoryConnection.php';
 require_once 'FedoraApi.php';
 
-class RepositoryTest extends PHPUnit_Framework_TestCase {
+use \PHPUnit\Framework\TestCase;
+
+class RepositoryTest extends TestCase {
 
   protected function setUp() {
     $connection = new RepositoryConnection(FEDORAURL, FEDORAUSER, FEDORAPASS);


### PR DESCRIPTION
## JIRA Ticket
https://jira.duraspace.org/browse/ISLANDORA-1935

## What does this Pull Request do?

Update to use namespaces in PHP unit so tests with PHP7 don't fail.

Some good info here:
https://thephp.cc/news/2017/02/migrating-to-phpunit-6

> While PHPUnit 5.7 has a forward compatibility layer, meaning you can already use PHPUnit\Framework\TestCase with that version, there is no backward compatibility layer in PHPUnit 6 that allows you to use

## How should this be tested?

Make sure travis doesn't fail, if it passes we should be all good.

## Interested parties
@DiegoPino @willtp87 