### PR TITLE
Throw exceptions when attempting to ingest an already existing datastream.

### DIFF
--- a/FedoraRelationships.php
+++ b/FedoraRelationships.php
@@ -266,6 +266,7 @@ abstract class FedoraRelationships extends MagicProperty {
       $this->datastream->content = $document->saveXml();
       if ($this->new) {
         $this->datastream->parent->ingestDatastream($this->datastream);
+        $this->new = FALSE;
       }
     }
     else {

--- a/Object.php
+++ b/Object.php
@@ -552,6 +552,9 @@ class NewFedoraObject extends AbstractFedoraObject {
    * @param NewFedoraDatastream $ds
    *   the datastream to be ingested
    *
+   * @throws DatastreamExistsException If the datastream already exists on the
+   * object.
+   *
    * @return mixed
    *   FALSE if the datastream already exists; TRUE otherwise.
    */
@@ -845,10 +848,8 @@ class FedoraObject extends AbstractFedoraObject {
       'formatURI' => $ds->format,
       'checksumType' => $ds->checksumType,
       'mimeType' => $ds->mimetype,
-      // Assume NewFedoraObjects will have a log message set.
-      'logMessage' => ($ds instanceof NewFedoraObject) ?
-        $ds->logMessage:
-        "Copied datastream from {$ds->parent->id}.",
+      // Assume NewFedoraDatastreams will have a log message set.
+      'logMessage' => ($ds instanceof NewFedoraDatastream) ? $ds->logMessage : "Copied datastream from {$ds->parent->id}.",
     );
     $temp = tempnam(sys_get_temp_dir(), 'tuque');
     if ($ds->controlGroup == 'E' || $ds->controlGroup == 'R' || $ds->getContent($temp) !== TRUE) {

--- a/Object.php
+++ b/Object.php
@@ -567,7 +567,7 @@ class NewFedoraObject extends AbstractFedoraObject {
       return TRUE;
     }
     else {
-      return FALSE;
+      throw new DatastreamExistsException("The datastream {$ds->id} already exists on the object {$ds->parent->id}");
     }
   }
 
@@ -834,39 +834,37 @@ class FedoraObject extends AbstractFedoraObject {
    */
   public function ingestDatastream(&$ds) {
     $this->populateDatastreams();
-    if (!isset($this->datastreams[$ds->id])) {
-      $params = array(
-        'controlGroup' => $ds->controlGroup,
-        'dsLabel' => $ds->label,
-        'versionable' => $ds->versionable,
-        'dsState' => $ds->state,
-        'formatURI' => $ds->format,
-        'checksumType' => $ds->checksumType,
-        'mimeType' => $ds->mimetype,
-        // Assume NewFedoraObjects will have a log message set.
-        'logMessage' => ($ds instanceof NewFedoraObject) ?
-          $ds->logMessage:
-          "Copied datastream from {$ds->parent->id}.",
-      );
-      $temp = tempnam(sys_get_temp_dir(), 'tuque');
-      if ($ds->controlGroup == 'E' || $ds->controlGroup == 'R' || $ds->getContent($temp) !== TRUE) {
-        $type = 'url';
-        $content = $ds->content;
-      }
-      else {
-        $type = 'file';
-        $content = $temp;
-      }
-      $dsinfo = $this->repository->api->m->addDatastream($this->id, $ds->id, $type, $content, $params);
-      unlink($temp);
-      $ds = new $this->fedoraDatastreamClass($ds->id, $this, $this->repository, $dsinfo);
-      $this->datastreams[$ds->id] = $ds;
-      $this->objectProfile['objLastModDate'] = $ds->createdDate;
-      return $ds;
+    if (isset($this->datastreams[$ds->id])) {
+      throw new DatastreamExistsException("The datastream {$ds->id} already exists on the object {$ds->parent->id}");
+    }
+    $params = array(
+      'controlGroup' => $ds->controlGroup,
+      'dsLabel' => $ds->label,
+      'versionable' => $ds->versionable,
+      'dsState' => $ds->state,
+      'formatURI' => $ds->format,
+      'checksumType' => $ds->checksumType,
+      'mimeType' => $ds->mimetype,
+      // Assume NewFedoraObjects will have a log message set.
+      'logMessage' => ($ds instanceof NewFedoraObject) ?
+        $ds->logMessage:
+        "Copied datastream from {$ds->parent->id}.",
+    );
+    $temp = tempnam(sys_get_temp_dir(), 'tuque');
+    if ($ds->controlGroup == 'E' || $ds->controlGroup == 'R' || $ds->getContent($temp) !== TRUE) {
+      $type = 'url';
+      $content = $ds->content;
     }
     else {
-      return FALSE;
+      $type = 'file';
+      $content = $temp;
     }
+    $dsinfo = $this->repository->api->m->addDatastream($this->id, $ds->id, $type, $content, $params);
+    unlink($temp);
+    $ds = new $this->fedoraDatastreamClass($ds->id, $this, $this->repository, $dsinfo);
+    $this->datastreams[$ds->id] = $ds;
+    $this->objectProfile['objLastModDate'] = $ds->createdDate;
+    return $ds;
   }
 
   /**

--- a/Object.php
+++ b/Object.php
@@ -555,8 +555,8 @@ class NewFedoraObject extends AbstractFedoraObject {
    * @throws DatastreamExistsException If the datastream already exists on the
    * object.
    *
-   * @return mixed
-   *   FALSE if the datastream already exists; TRUE otherwise.
+   * @return bool
+   *   TRUE if the datastream was ingested correctly.
    */
   public function ingestDatastream(&$ds) {
     if (!isset($this->datastreams[$ds->id])) {

--- a/RepositoryException.php
+++ b/RepositoryException.php
@@ -35,3 +35,8 @@ class RepositoryBadArguementException extends RepositoryException {}
  * This is thrown from the relationships class when something goes wrong
  */
 class RepositoryRelationshipsException extends RepositoryException {}
+
+/**
+ * This is thrown when a datastream already exists and attempted to be ingested.
+ */
+class DatastreamExistsException extends RepositoryException{}

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -249,4 +249,13 @@ class ObjectTest extends TestCase {
     $this->object->purgeDatastream($ds->id);
     $this->object->label = 'foo';
   }
+
+  /**
+   * @expectedException DatastreamExistsException
+   */
+  public function testDatastreamIngestOnExistingDatastream() {
+    $new_ds = $this->object->constructDatastream($this->testDsid, 'M');
+    $this->object->ingestDatastream($new_ds);
+  }
+
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1995

# What does this Pull Request do?
Changes unexpected behavior in Tuque where ingesting a datastream on an object that already has that datastream causes a `FALSE` to be returned rather than an exception thrown. This gets propagated up to the Tuque wrapper in Islandora and causes `islandora_datastream_ingested` hooks to be invoked on a non-existent `NewFedoraDatastream`.

# What's new?
Exception being tossed in the event a datastream is attempted to be added to a `NewFedoraObject` or `FedoraObject` that already exists on the object. Similarly, doing this uncovered a bug in the `FedoraRelationships` class that could lead to odd caching behavior when building up relationships on a `NewFedoraObject`.

# How should this be tested?
Enable the test module from: https://github.com/jordandukart/datastream_ingest_test
Re-ingest a collection that defines a TN from the required objects solution packs page (admin/islandora/solution_pack_config/solution_packs)
Note how the messages show that the Tuque wrapper from Islandora is invoking hooks with a `NewFedoraDatastream`
Pull Tuque code.
Repeat the process, note how we are now tossing an exception.

# Additional Notes:
Relates to https://github.com/Islandora/islandora/pull/678 and https://github.com/Islandora/islandora_solution_pack_collection/pull/191

* Could this change impact execution of existing code? Yes.
It's possible that somewhere someone is relying upon these ingestDatastream calls returning `FALSE` as opposed to exceptions.

# Interested parties
@DiegoPino, @dannylamb, @jonathangreen 
