### PR TITLE
add break statement

### DIFF
--- a/Datastream.php
+++ b/Datastream.php
@@ -680,6 +680,7 @@ class NewFedoraDatastream extends AbstractFedoraDatastream {
 
       case 'set':
         $this->datastreamInfo['dsChecksum'] = $value;
+        break;
 
       case 'unset':
         $this->datastreamInfo['dsChecksum'] = 'none';

--- a/Object.php
+++ b/Object.php
@@ -850,10 +850,11 @@ class FedoraObject extends AbstractFedoraObject {
       'checksum' => $ds->checksum,
       'mimeType' => $ds->mimetype,
       // Assume NewFedoraDatastreams will have a log message set.
-      'logMessage' => ($ds instanceof NewFedoraDatastream) ?
-        $ds->logMessage :
-        "Copied datastream from {$ds->parent->id}.",
+      'logMessage' => ($ds instanceof NewFedoraDatastream) ? $ds->logMessage : "Copied datastream from {$ds->parent->id}.",
     );
+    if ($ds->checksum !== 'none') {
+      $params['checksum'] = $ds->checksum;
+    }
     $temp = tempnam(sys_get_temp_dir(), 'tuque');
     if ($ds->controlGroup == 'E' || $ds->controlGroup == 'R' || $ds->getContent($temp) !== TRUE) {
       $type = 'url';

--- a/Object.php
+++ b/Object.php
@@ -847,7 +847,6 @@ class FedoraObject extends AbstractFedoraObject {
       'dsState' => $ds->state,
       'formatURI' => $ds->format,
       'checksumType' => $ds->checksumType,
-      'checksum' => $ds->checksum,
       'mimeType' => $ds->mimetype,
       // Assume NewFedoraDatastreams will have a log message set.
       'logMessage' => ($ds instanceof NewFedoraDatastream) ? $ds->logMessage : "Copied datastream from {$ds->parent->id}.",

--- a/Object.php
+++ b/Object.php
@@ -851,7 +851,7 @@ class FedoraObject extends AbstractFedoraObject {
       // Assume NewFedoraDatastreams will have a log message set.
       'logMessage' => ($ds instanceof NewFedoraDatastream) ? $ds->logMessage : "Copied datastream from {$ds->parent->id}.",
     );
-    if ($ds->checksum !== 'none') {
+    if (isset($ds->checksum)) {
       $params['checksum'] = $ds->checksum;
     }
     $temp = tempnam(sys_get_temp_dir(), 'tuque');

--- a/Object.php
+++ b/Object.php
@@ -842,6 +842,7 @@ class FedoraObject extends AbstractFedoraObject {
         'dsState' => $ds->state,
         'formatURI' => $ds->format,
         'checksumType' => $ds->checksumType,
+        'checksum' => $ds->checksum,
         'mimeType' => $ds->mimetype,
         // Assume NewFedoraObjects will have a log message set.
         'logMessage' => ($ds instanceof NewFedoraObject) ?

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -124,7 +124,6 @@ class NewDatastreamTest extends TestCase {
     $this->m->checksum = 'not this';
     $this->assertEquals('not this', $this->m->checksum);
     $this->object->ingestDatastream($this->m);
-    $this->repository->ingestObject($this->object);
   }
 
 }

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -121,9 +121,8 @@ class NewDatastreamTest extends TestCase {
   public function testSetChecksumBad() {
     $this->m->content = 'foo';
     $this->m->checksumType = 'MD5';
-    $bar_md5 = md5('bar');
-    $this->m->checksum = $bar_md5;
-    $this->assertEquals($bar_md5, $this->m->checksum);
+    $this->m->checksum = 'not this';
+    $this->assertEquals('not this', $this->m->checksum);
     $this->object->ingestDatastream($this->m);
   }
 

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -103,4 +103,28 @@ class NewDatastreamTest extends TestCase {
     $this->assertEquals('foo', file_get_contents($temp));
     unlink($temp);
   }
+
+  public function testSetChecksumGood() {
+    $this->m->content = 'foo';
+    $this->m->checksumType = 'MD5';
+    $foo_md5 = md5('foo');
+    $this->m->checksum = $foo_md5;
+    $this->assertEquals($foo_md5, $this->m->checksum);
+    $this->object->ingestDatastream($this->m);
+    $this->assertEquals($foo_md5, $this->object[$this->m->id]->checksum);
+  }
+
+  /**
+   * @expectedException     RepositoryException
+   * @expectedExceptionCode 500
+   */
+  public function testSetChecksumBad() {
+    $this->m->content = 'foo';
+    $this->m->checksumType = 'MD5';
+    $bar_md5 = md5('bar');
+    $this->m->checksum = $bar_md5;
+    $this->assertEquals($bar_md5, $this->m->checksum);
+    $this->object->ingestDatastream($this->m);
+  }
+
 }

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -124,6 +124,7 @@ class NewDatastreamTest extends TestCase {
     $this->m->checksum = 'not this';
     $this->assertEquals('not this', $this->m->checksum);
     $this->object->ingestDatastream($this->m);
+    $this->repository->ingestObject($this->object);
   }
 
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,7 +2,7 @@
   <php>
     <const name="FEDORAURL" value="http://localhost:8080/fedora"/>
     <const name="FEDORAUSER" value="fedoraAdmin"/>
-    <const name="FEDORAPASS" value="islandora"/>
+    <const name="FEDORAPASS" value="wei9bo0eethooD"/>
     <const name="TEST_PNG_URL" value="http://islandora.ca/testfiles/tuque/test.png"/>
     <const name="TEST_XML_URL" value="http://islandora.ca/testfiles/tuque/woo.xml"/>
   </php>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,7 +2,7 @@
   <php>
     <const name="FEDORAURL" value="http://localhost:8080/fedora"/>
     <const name="FEDORAUSER" value="fedoraAdmin"/>
-    <const name="FEDORAPASS" value="wei9bo0eethooD"/>
+    <const name="FEDORAPASS" value="islandora"/>
     <const name="TEST_PNG_URL" value="http://islandora.ca/testfiles/tuque/test.png"/>
     <const name="TEST_XML_URL" value="http://islandora.ca/testfiles/tuque/woo.xml"/>
   </php>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2009

# What does this Pull Request do?
Adds a `break` statement to the 'set' context of `NewFedoraDatastream::checksumMagicProperty()` so that setting the datastream checksum is not immediately followed up by unsetting it.

# What's new?
Applying values to `NewFedoraDatastream::checksum` should result in those values being accessible at `NewFedoraDatastream::checksum`.

Applying a correct checksum to `NewFedoraDatastream::checksum` and calling `FedoraObject::ingestDatastream()` on that datastream should result in no change.

Applying an incorrect checksum to `NewFedoraDatastream::checksum` and calling `FedoraObject::ingestDatastream()` on that datastream should result in a `RepositoryException` with a 500 code, as opposed to ignoring the given checksum and allowing one to be assigned by Fedora.

Similarly, applying an incorrect checksum to `NewFedoraDatastream::checksum` and calling `NewFedoraObject::ingestDatastream()` on that datastream and then calling `FedoraRepository::ingestObject()` on the object should also result in a `RepositoryException` with a 500 code.

# How should this be tested?
As this is pretty low-level, unit tests are being provided that check the above three cases. A tester is welcome to check this in the wild though:

```php
// From an Islandora context with devel installed:
$conn = islandora_get_tuque_connection();
$obj = $conn->repository->constructObject('test');
$ds = $obj->constructDatastream('TEST', 'M');
$ds->content = 'foo';
$ds->checksumType = 'MD5';
// This is obviously not a valid MD5 of 'foo'.
$ds->checksum = 'bar';
try {
  $obj->ingestDatastream($ds);
  $conn->repository->ingestObject($obj);
  dpm("We shouldn't be able to get here; ingesting a datastream with a mismatch is an exceptional case");
}
catch (RepositoryException $e) {
  dpm("That checksum ain't right");
}
```

Updating with this PR should give you the message in the caught `RepositoryException` section; before then, you get an ingested object that completely ignores the given checksum.

# Additional Notes:
This is an old, old bug (5+ years). The tuque documentation will have to be updated to say that checksums can be mutable. I cannot, for the life of me, envision a use case that relies on `NewFedoraDatastream::checksum` being immutable, but ... who knows.

Code that is currently applying checksums to `NewFedoraDatastream`s and ingesting them into `FedoraObjects` now throws `RepositoryException`s. Any code that was previously doing this simply failed silently (yikes ... checksums being provided by client code but not acknowledged by tuque?); it will now have to `catch` and handle the exception.

# Interested parties
This is pretty entrenched in there, so @Islandora/7-x-1-x-committers should be aware, as well as the maintainers @DiegoPino and @willtp87
