### PR TITLE
ISLANDORA-2053: Update travis.yml to force PHP 5.3 to run under Ubuntu Precise 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ language: php
 
 matrix:
   include:
-   #5.3.3 Ubuntu Precise exceptions
+   #5.3.1 Ubuntu Precise exceptions (not 5.3.3 since there is no SSL support there)
    # Fedora 3.5 has a bug that makes tests fail. we should deprecate it fully
     #- php: 5.3.3
     #  dist: precise
     #  env: FEDORA_VERSION="3.5"
-    - php: 5.3.3
+    - php: 5.3.1
       dist: precise
       env: FEDORA_VERSION="3.6.2"
-    - php: 5.3.3
+    - php: 5.3.1
       dist: precise
       env: FEDORA_VERSION="3.7.0"
-    - php: 5.3.3
+    - php: 5.3.1
       dist: precise
       env: FEDORA_VERSION="3.8.1"
 php:
@@ -32,8 +32,7 @@ env:
   - FEDORA_VERSION="3.8.1"
 
 before_script:
-  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi;
-  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer --prefer-source install; else composer install; fi;
+  - composer install
   - $TRAVIS_BUILD_DIR/tests/scripts/travis_setup.sh
 script:
   - vendor/bin/phpunit -c tests/travis.xml tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: php
 matrix:
   include:
    #5.3.3 Ubuntu Precise exceptions
-    - php: 5.3.3
-      dist: precise
-      env: FEDORA_VERSION="3.5"
+   # Fedora 3.5 has a bug that makes tests fail. we should deprecate it fully
+    #- php: 5.3.3
+    #  dist: precise
+    #  env: FEDORA_VERSION="3.5"
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.6.2"
@@ -24,7 +25,8 @@ php:
   - 7.0
   - 7.1
 env:
-  - FEDORA_VERSION="3.5"
+  # Fedora 3.5 has a bug that makes tests fail. we should deprecate it fully
+  # - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
+sudo: required
+dist: trusty
 language: php
+
+matrix:
+  include:
+   #5.3.3 Ubuntu Precise exceptions
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
 env:
+  - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
+
 before_script:
   - composer install
   - $TRAVIS_BUILD_DIR/tests/scripts/travis_setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ env:
   - FEDORA_VERSION="3.8.1"
 
 before_script:
-  - composer install
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi;
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer --prefer-source install; else composer install; fi;
   - $TRAVIS_BUILD_DIR/tests/scripts/travis_setup.sh
 script:
   - vendor/bin/phpunit -c tests/travis.xml tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ language: php
 
 matrix:
   include:
-   #5.3.1 Ubuntu Precise exceptions (not 5.3.3 since there is no SSL support there)
+   #5.3.10 Ubuntu Precise exceptions (not 5.3.3 since there is no SSL support there)
    # Fedora 3.5 has a bug that makes tests fail. we should deprecate it fully
-    #- php: 5.3.3
+    #- php: 5.3
     #  dist: precise
     #  env: FEDORA_VERSION="3.5"
-    - php: 5.3.1
+    - php: 5.3
       dist: precise
       env: FEDORA_VERSION="3.6.2"
-    - php: 5.3.1
+    - php: 5.3
       dist: precise
       env: FEDORA_VERSION="3.7.0"
-    - php: 5.3.1
+    - php: 5.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
 php:


### PR DESCRIPTION
**ISLANDORA-2053**: (https://jira.duraspace.org/browse/ISLANDORA-2053)
http://irclogs.islandora.ca/2017-09-05.html
https://github.com/travis-ci/travis-ci/issues/2963
https://github.com/Islandora/islandora/pull/683

As of September 2017, Travis-CI has removed support for PHP 5.3 (and 5.2) for their Ubuntu Trusty Images, forcing us, in order  to keep Drupal's compatibility matrix tested, to run Travis-CI test for 5.3 on Ubuntu Precise


# What does this Pull Request do?

This pull Fixes our failing Travis-CI tests: 
Should allow PHP 5.3.3 to run under Ubuntu Precise and Higher versions under Ubuntu Trusty.
Changes the way we define which PHP versions and Fedora ones run in Travis

# What's new?
We Moved PHP versions and Fedora ones into matrix section of the Travis YAML file. 

# How should this be tested?
 Travis-CI should pass and everything single PHP/FEDORA version combination should look good and very green.

# Interested parties
@Islandora/7-x-1-x-committers @jonathangreen 