### PR TITLE
Add getDatastreamProfile function and accompanying tests.

### DIFF
--- a/FedoraApi.php
+++ b/FedoraApi.php
@@ -319,10 +319,11 @@ class FedoraApiA {
    *   Persistent identifier of the digital object.
    * @param String $dsid
    *   Datastream identifier.
-   * @param array $as_of_date_time
+   * @param String $as_of_date_time
    *   (optional) Indicates that the result should be relative to the
    *     digital object as it existed at the given date and time. Defaults to
    *     the most recent version.
+   *     Format: YYYY-MM-DDTHH:MM:SS.SSSZ
    * @param array $file
    *   (optional) A file to retrieve the dissemination into.
    *

--- a/FedoraApi.php
+++ b/FedoraApi.php
@@ -347,6 +347,38 @@ class FedoraApiA {
   }
 
   /**
+   * Get the datastream profile.
+   *
+   * @param String $pid
+   *   Persistent identifier of the digital object.
+   * @param String $dsid
+   *   Datastream identifier.
+   * @param String|null $as_of_date_time
+   *   (optional) Indicates that the result should be relative to the
+   *     digital object as it existed at the given date and time. Defaults to
+   *     the most recent version.
+   *
+   * @throws RepositoryException
+   *
+   * @return array
+   *   The parsed datastream profile.
+   */
+  public function getDatastreamProfile($pid, $dsid, $as_of_date_time = NULL) {
+    $pid = urlencode($pid);
+    $dsid = urlencode($dsid);
+    $separator = '?';
+
+    $request = "/objects/$pid/datastreams/$dsid";
+    $this->connection->addParam($request,$separator, 'asOfDateTime', $as_of_date_time);
+    $this->connection->addParam($request,$separator, 'format', 'xml');
+
+    $response = $this->connection->getRequest($request, FALSE);
+
+    $response = $this->serializer->getDatastream($response);
+    return $response;
+  }
+
+  /**
    * Get a datastream dissemination from Fedora.
    *
    * @param String $pid

--- a/tests/FedoraApiTest.php
+++ b/tests/FedoraApiTest.php
@@ -612,6 +612,18 @@ class FedoraApiFindObjectsTest extends TestCase {
     $this->markTestIncomplete();
   }
 
+  function testGetDatastreamProfile() {
+    $actual = $this->apia->getDatastreamProfile($this->pids[0], 'fixture');
+    $this->assertEquals('label', $actual['dsLabel']);
+    $this->assertEquals('image/png', $actual['dsMIME']);
+  }
+
+  function testGetDatastreamProfileAsOfDate() {
+    $actual = $this->apia->getDatastreamProfile($this->pids[0], 'fixture', '2012-03-13T17:40:29.057Z');
+    $this->assertEquals('fixture.3', $actual['dsVersionID']);
+    $this->assertEquals('2012-03-13T17:40:29.057Z', $actual['dsCreateDate']);
+  }
+
   function testGetObjectHistory() {
     foreach ($this->fixtures as $pid => $fixture) {
       $actual = $this->apia->getObjectHistory($pid);


### PR DESCRIPTION
**JIRA Ticket**:

[ISLANDORA-2214](https://jira.duraspace.org/browse/ISLANDORA-2214)

# What does this Pull Request do?

Implements the getDatastream Fedora API-A function which returns the data stream profile.

# What's new?

* Added getDatastreamProfile function.
* Added accompanying tests.

# How should this be tested?

PHPUnit tests are included. testGetDatastreamProfile() and testGetDatastreamProfileAsOfDate().

@Islandora/7-x-1-x-committers @jonathangreen 